### PR TITLE
Add option to override command line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,9 @@ Configuration
 ``strict`` (default is False) refers to the ``strict`` option of ``mypy``.
     This option often is too strict to be useful.
 
+``overrides`` (default is ``[]``) specifies a list of alternate or supplemental command-line options.
+    This overrides the options passed to ``mypy`` or the mypy-specific ones passed to ``dmypy run``. When present, the special member ``True`` is replaced with the command line that would've been passed had this option not been specified. This option is especially handy when paired with a virtual environment. See relevant example below.
+
 Depending on your editor, the configuration (found in a file called pylsp-mypy.cfg in your workspace or a parent directory) should be roughly like this for a standard configuration:
 
 ::
@@ -53,6 +56,16 @@ With ``dmypy`` enabled your config should look like this:
         "dmypy": True,
         "strict": False
     }
+
+With ``overrides`` specified, your config should look like this:
+
+::
+
+    {
+        ...,
+        "overrides": ["--python-executable", "/tmp/bin/python", True]
+    }
+
 
 Developing
 -------------

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -17,6 +17,12 @@ TEST_LINE_WITHOUT_LINE = "test_plugin.py: " 'error: "Request" has no attribute "
 
 
 @pytest.fixture
+def diag_mp(monkeypatch):
+    monkeypatch.setattr(plugin, "last_diagnostics", plugin.collections.defaultdict(list))
+    return monkeypatch
+
+
+@pytest.fixture
 def workspace(tmpdir):
     """Return a workspace."""
     ws = Workspace(uris.from_fs_path(str(tmpdir)), Mock())
@@ -38,7 +44,7 @@ def test_settings():
     assert settings == {"plugins": {"pylsp_mypy": {}}}
 
 
-def test_plugin(workspace):
+def test_plugin(workspace, diag_mp):
     config = FakeConfig()
     doc = Document(DOC_URI, workspace, DOC_TYPE_ERR)
     plugin.pylsp_settings(config)
@@ -85,7 +91,7 @@ def test_parse_line_with_context(monkeypatch, word, bounds, workspace):
     assert diag["range"]["end"] == {"line": 278, "character": bounds[1]}
 
 
-def test_multiple_workspaces(tmpdir):
+def test_multiple_workspaces(tmpdir, diag_mp):
     DOC_SOURCE = """
 def foo():
     return

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -126,3 +126,85 @@ def foo():
     doc2 = Document(DOC_URI, ws2, DOC_SOURCE)
     diags = plugin.pylsp_lint(ws2._config, ws2, doc2, is_saved=False)
     assert len(diags) == 0
+
+
+def test_apply_overrides():
+    assert list(plugin.apply_overrides(["1", "2"], [])) == []
+    assert list(plugin.apply_overrides(["1", "2"], ["a"])) == ["a"]
+    assert list(plugin.apply_overrides(["1", "2"], ["a", True])) == ["a", "1", "2"]
+    assert list(plugin.apply_overrides(["1", "2"], [True, "a"])) == ["1", "2", "a"]
+    assert list(plugin.apply_overrides(["1"], ["a", True, "b"])) == ["a", "1", "b"]
+
+
+def test_option_overrides(tmpdir, diag_mp, workspace):
+    import sys
+    from textwrap import dedent
+
+    sentinel = tmpdir / "ran"
+
+    source = dedent(
+        """\
+        #!{}
+        import os, sys, pathlib
+        pathlib.Path({!r}).touch()
+        os.execv({!r}, sys.argv)
+        """
+    ).format(sys.executable, str(sentinel), sys.executable)
+
+    wrapper = tmpdir / "bin/wrapper"
+    wrapper.write(source, ensure=True)
+    wrapper.chmod(0o700)
+
+    overrides = ["--python-executable", wrapper.strpath, True]
+    diag_mp.setattr(
+        FakeConfig,
+        "plugin_settings",
+        lambda _, p: {"overrides": overrides} if p == "pylsp_mypy" else {},
+    )
+
+    assert not sentinel.exists()
+
+    diags = plugin.pylsp_lint(
+        config=FakeConfig(),
+        workspace=workspace,
+        document=Document(DOC_URI, workspace, DOC_TYPE_ERR),
+        is_saved=False,
+    )
+    assert len(diags) == 1
+    assert sentinel.exists()
+
+
+def test_option_overrides_dmypy(diag_mp, workspace):
+    from unittest.mock import Mock
+
+    overrides = ["--python-executable", "/tmp/fake", True]
+    diag_mp.setattr(
+        FakeConfig,
+        "plugin_settings",
+        lambda _, p: {
+            "overrides": overrides,
+            "dmypy": True,
+            "live_mode": False,
+        }
+        if p == "pylsp_mypy"
+        else {},
+    )
+
+    m = Mock(wraps=lambda a: (None, "", 0) if a == ["status"] else ("", "", None))
+    diag_mp.setattr(plugin.mypy_api, "run_dmypy", m)
+
+    plugin.pylsp_lint(
+        config=FakeConfig(),
+        workspace=workspace,
+        document=Document(DOC_URI, workspace, DOC_TYPE_ERR),
+        is_saved=False,
+    )
+    expected = [
+        "run",
+        "--",
+        "--python-executable",
+        "/tmp/fake",
+        "--show-column-numbers",
+        __file__,
+    ]
+    m.assert_called_with(expected)


### PR DESCRIPTION
This adds an option to supplement or replace the command line passed to mypy. It hopefully takes care of both #16 and #17.

#### To try:
1. If pytest is installed alongside your global mypy:
   1. create a temporary virtual environment and install this package's `requirements.txt`
   1. shadow your global mypy in your editor's `$PATH` with the one just installed
2. `cd` into your copy of `~/this-repo`
3. Open `test/test_plugin.py` and verify mypy complains pytest is missing
4. Check out this PR: `git fetch origin refs/pull/22/head && git checkout FETCH_HEAD`
5. Temporarily install an egg link globally: `~/my-global-python/bin/pip install -e .`
6. Create a virtual environment: `python -m venv .venv`
7. Install test deps: `./.venv/bin/pip install -e .[test]`
8. Configure your editor with something like:
   ``` yaml
   pylsp.plugins.pylsp_mypy.overrides:
     - "--python-executable"
     - "/home/me/this-repo/.venv/bin/python"
     - true # token to inject default options
   ```
9. Open `test/test_plugin.py` and verify that mypy does *not* complain about pytest being missing

#### Why not just a simple `python-executable` option instead?
A matter of taste, I suppose. However, IME, demand for an escape hatch to cover unforeseen use cases is inevitable, so might as well cut to the chase (by cutting out the middle man for all options passed directly to the underlying service). For example, GCC and clang have their `-Xassembler`, `-Xlinker`, and `-Xpreprocessor` options for doing just that. A more fitting example might be the libvirt tool `virt-install`, which exposes the QEMU backend via a `--qemu-commandline` option. But I suppose there's no reason (other than slippery-slope avoidance) that a specific `interpreter` option couldn't live alongside this one.

#### Why not just rely on discovered config files?
Although configs are typically tracked in version control, there's nothing to stop a user from modifying them temporarily, so maintainers typically look to commit hooks and CI jobs for enforcement. And while it might seem sensible for a project to keep its mypy settings in a location with a lower priority, like a `pyproject.toml`, the fact that merging doesn't occur between configs means a contributor with special needs would have to constantly ensure theirs is up to date regardless. This can be annoying when the options they most likely want modified (IME) are top-level environmental ones, which have a lower precedence than command-line options (which in turn are lower than section-specific options). For example, my editor wants `show-error-codes` for muting directives via `# type: ignore[foo]` (which really should be an LSP-provided action). But were I the maintainer, would it really make sense to foist `show-error-codes` on everyone?

---
*Note*: this patch was based on one submitted to the old forked project after it went dormant. It's been reworked and submitted here with permission from the original author, who no longer uses Python.

*Edits*: improve interface; remember how to use Markdown; add "why not" rationales; improve demo walkthrough steps.