### PR TITLE
chore: add missing config setting and allow mypy 0.920

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-lsp-server
-mypy < 0.920
+mypy
 black
 pre-commit
 rstcheck

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >= 3.6
 packages = find:
 install_requires =
     python-lsp-server
-    mypy < 0.920
+    mypy
 
 
 [options.entry_points]

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -103,7 +103,9 @@ def foo():
 
     # Create configuration file for workspace folder 1.
     mypy_config = folder1.join("mypy.ini")
-    mypy_config.write("[mypy]\nwarn_unreachable = True")
+    mypy_config.write(
+        "[mypy]\nwarn_unreachable = True\ncheck_untyped_defs = True"
+    )
 
     # Initialize settings for both folders.
     plugin.pylsp_settings(ws1._config)

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -103,9 +103,7 @@ def foo():
 
     # Create configuration file for workspace folder 1.
     mypy_config = folder1.join("mypy.ini")
-    mypy_config.write(
-        "[mypy]\nwarn_unreachable = True\ncheck_untyped_defs = True"
-    )
+    mypy_config.write("[mypy]\nwarn_unreachable = True\ncheck_untyped_defs = True")
 
     # Initialize settings for both folders.
     plugin.pylsp_settings(ws1._config)


### PR DESCRIPTION
Added `check_untyped_defs` the to test for unreachable code. This removes the restriction for `mypy < 0.920`.